### PR TITLE
[CAPAY-419] Bump joda-money for update to currency code of Curaçao and Sint Maarten

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -5,7 +5,7 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.8.0"]
-                 [org.joda/joda-money "1.0.5"]]
+                 [org.joda/joda-money "2.0.1"]]
   :profiles {:dev {:plugins      [[codox "0.8.10"]]
                    :dependencies [[com.novemberain/monger "2.0.0"]
                                   [cheshire               "5.3.1"]

--- a/test/clojurewerkz/money/currencies_test.clj
+++ b/test/clojurewerkz/money/currencies_test.clj
@@ -24,7 +24,9 @@
   (are [code unit] (is (= unit (cu/of-country code) (cu/for-country code)))
     "CH" cu/CHF
     "RU" cu/RUB
-    "LV" cu/EUR))
+    "LV" cu/EUR
+    "SX" (CurrencyUnit/of "XCG")
+    "CW" (CurrencyUnit/of "XCG")))
 
 (deftest test-pseudo-currency
   (is (cu/pseudo-currency? (cu/of "XXX")))
@@ -36,7 +38,8 @@
 (deftest test-numeric-code-of
   (are [code unit] (is (= code (cu/numeric-code-of unit)))
      756 cu/CHF
-     643 cu/RUB))
+     643 cu/RUB
+     532 (CurrencyUnit/of "XCG")))
 
 (deftest test-code->numeric-code
   (are [numeric-code code] (is (= numeric-code (cu/code->numeric-code code)))


### PR DESCRIPTION
https://www.marqeta.com/docs/developer-guides/card-network-certifications/#_article_2_6_changes_to_currency_code_for_cura%C3%A7ao_and_sint_maarten